### PR TITLE
fix author link

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ If you have found a bug or if you have a feature request, please report them at 
 
 ## Author
 
-[Auth0](auth0.com)
+[Auth0](https://auth0.com/)
 
 ## License
 


### PR DESCRIPTION
was missing "https://" therefore was redirecting to "https://github.com/auth0/cxn/blob/master/auth0.com" rather than "https://auth0.com"
